### PR TITLE
fix: vault auth region

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -231,6 +231,7 @@ func createIAMLoginVars() (map[string]interface{}, error) {
 	for _, v := range []string{"VAULT_AUTH_AWS_REGION", "AWS_REGION", "AWS_DEFAULT_REGION"} {
 		if r := env.Getenv(v); v != "" {
 			region = r
+			break
 		}
 	}
 


### PR DESCRIPTION
I believe this list of env names is in the intended order of precedence, so this `break` simply ensures the value is not overwritten by lower-precedence values.